### PR TITLE
Rearranged expected/actual to be a little more logical

### DIFF
--- a/js/koans/aboutModels.js
+++ b/js/koans/aboutModels.js
@@ -20,19 +20,18 @@ describe('About Backbone.Model', function() {
     it('Attributes can be set on the model instance when it is created.', function() {
         var todo = new Todo({ text: 'Get oil change for car.' });
         
-        var expectedText = 'FIX ME';
-        
-        expect(expectedText).toEqual(todo.get('text'));
+        expect(todo.get('text')).toEqual('FIX ME');
     });
     
     it('If it is exists, an initialize function on the model will be called when it is created.', function() {
-        var todo = new Todo({ text: 'Stop monkeys from throwing their own feces!' });
         
         // Why does the expected text differ from what is passed in when we create the Todo?
         // What is happening in Todo.initialize? (see js/todos.js line 22)
-        // You can get this test passing without changing todos.js or the expected text.
-        
-        expect('Stop monkeys from throwing their own double rainbows!').toBe(todo.get('text'));
+        // You can get this test passing without changing todos.js or actualText.
+        var todo = new Todo({ text: 'Stop monkeys from throwing their own feces!' });
+
+        actualText = 'Stop monkeys from throwing their own double rainbows!'; // Don't change
+        expect(todo.get('text')).toBe(actualText);
     });
     
     it('Fires a custom event when the state changes.', function() {


### PR DESCRIPTION
I found the expected/actual switch arounds in the Models koans a little weird. Also, probably because of these changes I found the intent behind the "double rainbows" koan a little confusing, even through I knew about the "NAUGHTY_WORDS" filter.

This is highly subjective, but these changes are my take on what would be more logical with minimal confusion to the student.

Once again I've tested with an answer set in test_rearranged_expected branch on my fork. Sad but true.
