### PR TITLE
Fixed completion count for Collections

### DIFF
--- a/js/koans/aboutCollections.js
+++ b/js/koans/aboutCollections.js
@@ -1,16 +1,16 @@
 describe('About Backbone.Collection', function() {
     it('Can add Model instances as objects one at a time, or as arrays of models.', function() {
         var todos = new TodoList();
-        
-        expect(todos.length).toBe(0);
+                
+        expect(todos.length).toBe('FIX ME');
         
         todos.add({ text: 'Clean the kitchen' });
         
-        expect(todos.length).toEqual(1);
+        expect(todos.length).toBe('FIX ME');
         
         // How would you add multiple models to the collection with a single method call?
         
-        expect(todos.length).toEqual(3);
+        expect(todos.length).toBe(3);
     });
     
     it('Can have a comparator function to keep the collection sorted.', function() {
@@ -23,12 +23,12 @@ describe('About Backbone.Collection', function() {
         //
         // Hint: Could you change attribute values on the todos themselves?
         
-        todos.add([{ text: 'Do the laundry',  order: 4},
-                   { text: 'Clean the house', order: 8},
+        todos.add([{ text: 'Clean the house', order: 8},
+                   { text: 'Do the laundry',  order: 4},
                    { text: 'Take a nap',      order: 3}]);
         
-        expect(todos.at(0).get('text')).toEqual('Clean the house');
-        expect(todos.at(1).get('text')).toEqual('Do the laundry');
+        expect(todos.at(0).get('text')).toEqual('Do the laundry');
+        expect(todos.at(1).get('text')).toEqual('Clean the house');
         expect(todos.at(2).get('text')).toEqual('Take a nap');
     });
     
@@ -45,7 +45,11 @@ describe('About Backbone.Collection', function() {
         
         expect(todos.length).toEqual(1);
         expect(addModelCallback).toHaveBeenCalled();
-        
+    });
+
+    it('Can remove items from the collection.', function() {        
+        var todos = new TodoList({ text: 'Iron your tights'});
+      
         var removeModelCallback = jasmine.createSpy('-remove model callback-');
         todos.bind('remove', removeModelCallback);
         


### PR DESCRIPTION
On starting the koans the Collections koans are showing 4 of 10 completed. Oh noes!

I've messed about with Collections so that it shows 0 of 10 completed. Yes, I have no life!

I've tested it on the test_fix_completion_count_for_collections branch of my fork.

Good news, thats the last pull request. For now :)
